### PR TITLE
feat: Implement Jinzai Works dashboard UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import Dashboard from './Dashboard';
+import JinzaiDashboard from './JinzaiDashboard'; // Changed to import JinzaiDashboard
 // import Login from './Login'; // Import the Login component - Unused for now
 import './App.css';
 import DashboardLayout from './DashboardLayout';
@@ -37,9 +37,10 @@ function App() {
   // );
 
   // Current simplified setup:
+  // The `title` prop for DashboardLayout is removed as the title is now set within DashboardLayout's AppBar.
   return (
-    <DashboardLayout title="Leave-O-Meter">
-      <Dashboard />
+    <DashboardLayout>
+      <JinzaiDashboard />
     </DashboardLayout>
   );
 }

--- a/src/DashboardLayout.tsx
+++ b/src/DashboardLayout.tsx
@@ -11,15 +11,27 @@ import IconButton from '@mui/material/IconButton';
 import MenuIcon from '@mui/icons-material/Menu';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import ListItem from '@mui/material/ListItem';
+// Removed unused ListItem import
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import InboxIcon from '@mui/icons-material/MoveToInbox';
-import MailIcon from '@mui/icons-material/Mail';
-import { ColorModeContext } from './theme';
+import { ColorModeContext } from './theme'; // Keep this for theme toggle
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
+import CssBaseline from '@mui/material/CssBaseline';
+import Avatar from '@mui/material/Avatar'; // Added for logo
+import Badge from '@mui/material/Badge'; // Added for notification badge
+
+// MUI Icons for Sidebar and App Bar
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import ForumIcon from '@mui/icons-material/Forum';
+import BeachAccessIcon from '@mui/icons-material/BeachAccess';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import HomeWorkIcon from '@mui/icons-material/HomeWork';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 
 const drawerWidth = 240;
 
@@ -94,13 +106,14 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
 
 interface DashboardLayoutProps {
   children: ReactNode;
-  title?: string; // Optional title for the header
+  // title prop is no longer needed as it's hardcoded in AppBar
 }
 
-const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, title = "Dashboard" }) => {
+const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const theme = useTheme();
   const colorMode = React.useContext(ColorModeContext);
   const [open, setOpen] = useState(true); // Drawer is open by default
+  const [selectedItem, setSelectedItem] = useState('Dashboard'); // State for selected item
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -110,9 +123,23 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, title = "Da
     setOpen(false);
   };
 
+  const handleListItemClick = (text: string) => {
+    setSelectedItem(text);
+    // Add navigation logic here if needed in the future
+  };
+
+  const menuItems = [
+    { text: 'Dashboard', icon: <DashboardIcon /> },
+    { text: 'IV Forum', icon: <ForumIcon /> },
+    { text: 'Leave', icon: <BeachAccessIcon /> },
+    { text: 'Attendance', icon: <CalendarTodayIcon /> },
+    { text: 'Work From Home', icon: <HomeWorkIcon /> },
+  ];
+
   return (
     <Box sx={{ display: 'flex' }}>
-      <AppBar position="fixed" open={open}>
+      <CssBaseline /> {/* Added CssBaseline */}
+      <AppBar position="sticky" open={open} color="default" elevation={1}> {/* Changed position and color, added elevation */}
         <Toolbar>
           <IconButton
             color="inherit"
@@ -120,56 +147,82 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children, title = "Da
             onClick={handleDrawerOpen}
             edge="start"
             sx={{
-              marginRight: 5,
+              marginRight: 5, // Keep margin for consistency
               ...(open && { display: 'none' }),
             }}
           >
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
-            {title}
+            Jinzai Works
           </Typography>
+          <IconButton color="inherit">
+            <Badge badgeContent="99+" color="error">
+              <NotificationsIcon />
+            </Badge>
+          </IconButton>
+          <IconButton color="inherit">
+            <RefreshIcon />
+          </IconButton>
+          <IconButton color="inherit">
+            <HelpOutlineIcon />
+          </IconButton>
+          <IconButton color="inherit">
+            <AccountCircleIcon />
+          </IconButton>
           <IconButton sx={{ ml: 1 }} onClick={colorMode.toggleColorMode} color="inherit">
             {theme.palette.mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
           </IconButton>
         </Toolbar>
       </AppBar>
       <Drawer variant="permanent" open={open}>
-        <DrawerHeader>
+        <DrawerHeader sx={{ display: 'flex', alignItems: 'center', justifyContent: open ? 'space-between' : 'flex-end', px: open ? 2 : 1 }}>
+          {open && (
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+              <Avatar sx={{ mr: 1, bgcolor: 'primary.main' }}>J</Avatar> {/* Placeholder Logo */}
+              <Typography variant="h6" component="div">Jinzai</Typography>
+            </Box>
+          )}
           <IconButton onClick={handleDrawerClose}>
             {theme.direction === 'rtl' ? <ChevronRightIcon /> : <ChevronLeftIcon />}
           </IconButton>
         </DrawerHeader>
         <Divider />
         <List>
-          {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-            <ListItem key={text} disablePadding sx={{ display: 'block' }}>
-              <ListItemButton
+          {menuItems.map((item) => (
+            <ListItemButton
+              key={item.text}
+              selected={selectedItem === item.text}
+              onClick={() => handleListItemClick(item.text)}
+              sx={{
+                minHeight: 48,
+                justifyContent: open ? 'initial' : 'center',
+                px: 2.5,
+                '&.Mui-selected': {
+                    backgroundColor: theme.palette.action.selected, // Use theme's selected color
+                    '&:hover': {
+                        backgroundColor: theme.palette.action.hover, // Use theme's hover color
+                    }
+                }
+              }}
+            >
+              <ListItemIcon
                 sx={{
-                  minHeight: 48,
-                  justifyContent: open ? 'initial' : 'center',
-                  px: 2.5,
+                  minWidth: 0,
+                  mr: open ? 3 : 'auto',
+                  justifyContent: 'center',
                 }}
               >
-                <ListItemIcon
-                  sx={{
-                    minWidth: 0,
-                    mr: open ? 3 : 'auto',
-                    justifyContent: 'center',
-                  }}
-                >
-                  {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                </ListItemIcon>
-                <ListItemText primary={text} sx={{ opacity: open ? 1 : 0 }} />
-              </ListItemButton>
-            </ListItem>
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText primary={item.text} sx={{ opacity: open ? 1 : 0 }} />
+            </ListItemButton>
           ))}
         </List>
-        <Divider />
-        {/* Add more list items or sections here */}
       </Drawer>
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        <DrawerHeader /> {/* This is to offset content below Appbar */}
+      {/* Main content area - AppBar is sticky, so content will scroll under it. No DrawerHeader needed here if AppBar is sticky. */}
+      <Box component="main" sx={{ flexGrow: 1, p: 3, paddingTop: '0px' /* Ajust if sticky AppBar creates unwanted space */ }}>
+        {/* <DrawerHeader /> We might not need this offset if AppBar is sticky and not fixed */}
         {children}
       </Box>
     </Box>

--- a/src/JinzaiDashboard.tsx
+++ b/src/JinzaiDashboard.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+  Icon as MuiIcon, // Renamed to avoid conflict if user defines a local 'Icon'
+} from '@mui/material';
+import BadgeIcon from '@mui/icons-material/Badge';
+import DomainIcon from '@mui/icons-material/Domain';
+
+// Hardcoded data
+const user = {
+  name: 'Jules Verne',
+  email: 'jules.verne@example.com',
+  avatarUrl: '/path/to/avatar.jpg', // Replace with a real path or remove if not available
+  empId: 'EMP007',
+  domain: 'Technology',
+};
+
+const project = {
+  name: 'AC_CORE',
+  role: 'SOFTWARE TRAINEE',
+  joinDate: '2023-01-15',
+  division: 'WAP-AC',
+  location: 'Chennai',
+};
+
+const leaveTypes = [
+  { key: 'EL', label: 'EL', icon: '⏳', balance: 5, allotted: 12 },
+  { key: 'CL', label: 'CL', icon: '🗓️', balance: 2, allotted: 7 },
+  { key: 'SL', label: 'SL', icon: '🤒', balance: 8, allotted: 10 },
+];
+
+const wfhTypes = [
+  { key: 'GENERAL', label: 'GENERAL', icon: '🏠', balance: 3, allotted: 6 },
+  { key: 'SPECIAL', label: 'SPECIAL', icon: '🏡', balance: 1, allotted: 2 },
+];
+
+const cardStyle = {
+  borderRadius: 2,
+  boxShadow: 1,
+  height: '100%', // Ensure cards in the same row have the same height
+};
+
+const JinzaiDashboard: React.FC = () => {
+  return (
+    <Box p={3}>
+      <Grid container spacing={3}>
+        {/* My Basic Info Card */}
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined" sx={cardStyle}>
+            <CardHeader title="My Basic Info" />
+            <CardContent>
+              <Box display="flex" alignItems="center" mb={2}>
+                <Avatar src={user.avatarUrl} sx={{ width: 56, height: 56 }}>
+                  {user.name.charAt(0)} {/* Fallback to initial if avatar fails */}
+                </Avatar>
+                <Box ml={2}>
+                  <Typography variant="h6">{user.name}</Typography>
+                  <Typography variant="body2" color="textSecondary">{user.email}</Typography>
+                </Box>
+              </Box>
+              <List dense>
+                <ListItem>
+                  <ListItemIcon><BadgeIcon /></ListItemIcon>
+                  <ListItemText primary="Emp ID" secondary={user.empId} />
+                </ListItem>
+                <ListItem>
+                  <ListItemIcon><DomainIcon /></ListItemIcon>
+                  <ListItemText primary="Domain Name" secondary={user.domain} />
+                </ListItem>
+              </List>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* My Current Project Info Card */}
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined" sx={cardStyle}>
+            <CardHeader title="My Current Project Info" />
+            <CardContent>
+              <Table size="small">
+                <TableBody>
+                  {[
+                    ['Project Name', project.name],
+                    ['Role', project.role],
+                    ['Project Joining Date', project.joinDate || '-'],
+                    ['Org-Division', project.division],
+                    ['Location', project.location],
+                  ].map(([label, value]) => (
+                    <TableRow key={label}>
+                      <TableCell sx={{ fontWeight: 'medium' }}>{label}</TableCell>
+                      <TableCell>{value || '-'}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* My Leave Balance Card */}
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined" sx={cardStyle}>
+            <CardHeader title="My Leave Balance" />
+            <CardContent>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Leave Type</TableCell>
+                    <TableCell align="right">Balance</TableCell>
+                    <TableCell align="right">Allotted</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {leaveTypes.map(type => (
+                    <TableRow key={type.key}>
+                      <TableCell>
+                        <Box component="span" mr={1} sx={{ verticalAlign: 'middle' }}>
+                           {/* Using MuiIcon for material icons, or direct emoji */}
+                           {type.icon.length > 2 ? <MuiIcon fontSize="small">{type.icon}</MuiIcon> : type.icon}
+                        </Box>
+                        {type.label}
+                      </TableCell>
+                      <TableCell align="right">{type.balance}</TableCell>
+                      <TableCell align="right">{type.allotted}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* My WFH Balance Card */}
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined" sx={cardStyle}>
+            <CardHeader title="My WFH Balance" />
+            <CardContent>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>WFH Type</TableCell>
+                    <TableCell align="right">Balance</TableCell>
+                    <TableCell align="right">Allotted</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {wfhTypes.map(type => (
+                    <TableRow key={type.key}>
+                      <TableCell>
+                        <Box component="span" mr={1} sx={{ verticalAlign: 'middle' }}>
+                          {/* Using MuiIcon for material icons, or direct emoji */}
+                          {type.icon.length > 2 ? <MuiIcon fontSize="small">{type.icon}</MuiIcon> : type.icon}
+                        </Box>
+                        {type.label}
+                      </TableCell>
+                      <TableCell align="right">{type.balance}</TableCell>
+                      <TableCell align="right">{type.allotted}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default JinzaiDashboard;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,42 +1,46 @@
 import { PaletteMode, createTheme } from '@mui/material';
-import { amber, deepOrange, grey } from '@mui/material/colors';
+import { grey } from '@mui/material/colors'; // Removed amber and deepOrange
 import React from 'react';
 
-// Define placeholder brand tokens
-const placeholderBrandColors = {
-  primary: amber, // Example primary color
-  secondary: deepOrange, // Example secondary color
-  neutral: grey, // Example neutral color
+// Define Jinzai brand tokens
+const jinzaiBrandColors = {
+  primary: '#0D47A1',
+  secondary: '#1976D2',
+  neutral: grey,
 };
 
 export const getDesignTokens = (mode: PaletteMode) => ({
   palette: {
     mode,
+    primary: {
+      main: jinzaiBrandColors.primary,
+    },
+    secondary: {
+      main: jinzaiBrandColors.secondary,
+    },
     ...(mode === 'light'
       ? {
           // Palette values for light mode
-          primary: placeholderBrandColors.primary,
-          divider: placeholderBrandColors.primary[200],
+          divider: jinzaiBrandColors.neutral[300], // Adjusted divider for better visibility
           text: {
-            primary: placeholderBrandColors.neutral[900],
-            secondary: placeholderBrandColors.neutral[800],
+            primary: jinzaiBrandColors.neutral[900],
+            secondary: jinzaiBrandColors.neutral[700], // Adjusted for better contrast
           },
           background: {
             default: '#ffffff',
-            paper: placeholderBrandColors.neutral[50],
+            paper: jinzaiBrandColors.neutral[50],
           }
         }
       : {
           // Palette values for dark mode
-          primary: placeholderBrandColors.secondary,
-          divider: placeholderBrandColors.neutral[700],
+          divider: jinzaiBrandColors.neutral[700],
           background: {
-            default: placeholderBrandColors.neutral[900],
-            paper: placeholderBrandColors.neutral[800],
+            default: jinzaiBrandColors.neutral[900],
+            paper: jinzaiBrandColors.neutral[800],
           },
           text: {
             primary: '#fff',
-            secondary: placeholderBrandColors.neutral[500],
+            secondary: jinzaiBrandColors.neutral[400], // Adjusted for better visibility
           },
         }),
   },


### PR DESCRIPTION
- Implemented the main dashboard page (JinzaiDashboard.tsx) with four key info cards: My Basic Info, My Current Project Info, My Leave Balance, and My WFH Balance, using hardcoded data.
- Updated DashboardLayout.tsx:
    - Revised sidebar navigation with new items (Dashboard, IV Forum, Leave, etc.) and MUI icons.
    - Added a placeholder logo to the sidebar.
    - Implemented selection highlighting for the active sidebar item.
    - Configured the App Bar with the title "Jinzai Works", sticky positioning, and new action icons (Notifications, Refresh, Help, User).
    - Integrated CssBaseline for consistent styling.
- Updated src/theme.ts with the specified custom color palette (primary: #0D47A1, secondary: #1976D2).
- Modified App.tsx to render the new JinzaiDashboard within the DashboardLayout.
- Ensured @mui/icons-material package is installed for all necessary icons.