### PR TITLE
feat: Show logo in minimized app drawer

### DIFF
--- a/src/DashboardLayout.tsx
+++ b/src/DashboardLayout.tsx
@@ -195,11 +195,15 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
           {/* Space for icon and title */}
           {open && (
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-start', width: '100%', paddingLeft: 1, paddingTop: 1, paddingBottom: 1 }}>
-              {/* Placeholder for an icon, you can replace <img> with an Icon component */}
               <img src={logoWhite} alt="Jinzai Logo" style={{ width: 40, height: 40, marginRight: 16 }} />
               <Typography variant="h5" noWrap component="div" sx={{ fontWeight: 'bold' }}>
                 Jinzai
               </Typography>
+            </Box>
+          )}
+          {!open && (
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: '100%', paddingTop: 1, paddingBottom: 1 }}>
+              <img src={logoWhite} alt="Jinzai Logo" style={{ width: 40, height: 40 }} />
             </Box>
           )}
         </DrawerHeader>


### PR DESCRIPTION
This change modifies the DashboardLayout component to display the white logo when the app drawer is minimized. The logo is centered and styled appropriately within the minimized drawer.