### PR TITLE
Fix: Correct Grid component usage in Login page

### DIFF
--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -86,12 +86,12 @@ const Login = () => {
                 Sign In
               </Button>
               <Grid container justifyContent="space-between"> {/* Added justifyContent */}
-                <Grid size="grow"> {/* Takes available space */}
+                <Grid item xs> {/* Takes available space */}
                   <Link href="#" variant="body2">
                     Forgot password?
                   </Link>
                 </Grid>
-                <Grid> {/* Takes content width */}
+                <Grid item> {/* Takes content width */}
                   <Link href="#" variant="body2">
                     {"Don't have an account? Sign Up"}
                   </Link>


### PR DESCRIPTION
This commit fixes an issue where the Material UI Grid component was used incorrectly in the Login page. The `size="grow"` prop is not a valid prop for the Grid component and has been replaced with `item xs` to achieve the desired layout.

This change is expected to resolve a potential rendering issue on the login page, which might have contributed to a white screen being displayed when navigating to the /leave page without authentication.