### PR TITLE
Refactor: Remove Celery/Redis and use SQLite

### DIFF
--- a/new_project_jules/backend/app/core/celery_app.py
+++ b/new_project_jules/backend/app/core/celery_app.py
@@ -1,5 +1,0 @@
-from celery import Celery
-
-celery_app = Celery("worker", broker="redis://redis:6379/0")
-
-celery_app.conf.task_routes = {"app.tasks.*": "main-queue"}

--- a/new_project_jules/backend/app/core/config.py
+++ b/new_project_jules/backend/app/core/config.py
@@ -1,7 +1,3 @@
-import os
-
 PROJECT_NAME = "My FastAPI React App"
-
-SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
 
 API_V1_STR = "/api/v1"

--- a/new_project_jules/backend/app/db/session.py
+++ b/new_project_jules/backend/app/db/session.py
@@ -2,10 +2,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from app.core import config
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 
 engine = create_engine(
-    config.SQLALCHEMY_DATABASE_URI,
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/new_project_jules/backend/app/main.py
+++ b/new_project_jules/backend/app/main.py
@@ -7,8 +7,6 @@ from app.api.api_v1.routers.auth import auth_router
 from app.core import config
 from app.db.session import SessionLocal
 from app.core.auth import get_current_active_user
-from app.core.celery_app import celery_app
-from app import tasks
 
 
 app = FastAPI(
@@ -27,13 +25,6 @@ async def db_session_middleware(request: Request, call_next):
 @app.get("/api/v1")
 async def root():
     return {"message": "Hello World"}
-
-
-@app.get("/api/v1/task")
-async def example_task():
-    celery_app.send_task("app.tasks.example_task", args=["Hello World"])
-
-    return {"message": "success"}
 
 
 # Routers

--- a/new_project_jules/backend/app/tasks.py
+++ b/new_project_jules/backend/app/tasks.py
@@ -1,6 +1,2 @@
-from app.core.celery_app import celery_app
-
-
-@celery_app.task(acks_late=True)
-def example_task(word: str) -> str:
-    return f"test task returns {word}"
+# This file is intentionally left empty after removing Celery tasks.
+# It can be deleted if no other background tasks are planned for the future.


### PR DESCRIPTION
- Removed Celery application and Redis configuration.
- Updated SQLAlchemy engine to use SQLite.
- Removed Celery-specific code from main application and tasks.