### PR TITLE
Fix: Ensure proper indentation for submenu items

### DIFF
--- a/new_project_jules/frontend/src/DashboardLayout.tsx
+++ b/new_project_jules/frontend/src/DashboardLayout.tsx
@@ -285,10 +285,10 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                         selected={selectedItem === child.text}
                         onClick={() => handleListItemClick(child.text, child.path)}
                         sx={{
-                          pl: 4, // Indent child items
+                          paddingLeft: theme.spacing(4), // Explicitly set left padding for indentation
+                          paddingRight: theme.spacing(2.5), // Maintain right padding
                           minHeight: 48,
                           justifyContent: open ? 'initial' : 'center',
-                          px: 2.5,
                         }}
                       >
                         <ListItemIcon


### PR DESCRIPTION
Changed the sx prop for child ListItemButton components in DashboardLayout.tsx to use explicit `paddingLeft` and `paddingRight` values.

This prevents the `px` shorthand property from overriding the intended `pl` (padding-left) for indentation, ensuring that sub-items are visually indented under their parent menu items.