### PR TITLE
Fix: Resolve excessive spacing next to maximized app drawer

### DIFF
--- a/new_project_jules/frontend/src/DashboardLayout.tsx
+++ b/new_project_jules/frontend/src/DashboardLayout.tsx
@@ -316,14 +316,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
           flexGrow: 1,
           bgcolor: 'background.default',
           minHeight: '100vh',
-          transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: open ? theme.transitions.duration.enteringScreen : theme.transitions.duration.leavingScreen,
-          }),
-          marginLeft: open ? `${drawerWidth}px` : 0,
-          [theme.breakpoints.up('sm')]: {
-            marginLeft: open ? `${drawerWidth}px` : 0,
-          },
+          // Removed transition for margin and marginLeft property
           pt: typeof theme.mixins.toolbar.minHeight === 'number'
               ? `calc(${theme.mixins.toolbar.minHeight}px + ${theme.spacing(3)})`
               : `calc(64px + ${theme.spacing(3)})`,


### PR DESCRIPTION
Removed redundant marginLeft from the main content area in DashboardLayout.tsx. The flexbox layout now correctly positions the content next to the drawer, eliminating the large gap when the drawer is open. The AppBar and Drawer transitions and positioning are unaffected and continue to work as expected.