### PR TITLE
feat: Implement superuser management of employee leaves and WFH

### DIFF
--- a/new_project_jules/backend/app/api/api_v1/routers/leaves.py
+++ b/new_project_jules/backend/app/api/api_v1/routers/leaves.py
@@ -4,13 +4,15 @@ import typing as t
 
 from app.db.session import get_db
 from app.db import crud, schemas
-from app.core.auth import get_current_active_user
+from app.core.auth import get_current_active_user, get_current_active_superuser
 from app.db.models import User
 
 leaves_router = r = APIRouter()
 
+# Regular user endpoints (prefixed with /user for clarity, or keep as is if preferred)
+
 @r.post("/leaves", response_model=schemas.Leave, status_code=201)
-async def create_leave_request(
+async def create_leave_request_for_self(
     leave_in: schemas.LeaveCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -19,9 +21,7 @@ async def create_leave_request(
     Create a new leave request for the current user.
     """
     if leave_in.user_id != current_user.id:
-        # This is a check to ensure that the user_id in the payload matches the authenticated user.
-        # Alternatively, we can ignore leave_in.user_id and always use current_user.id
-        raise HTTPException(status_code=403, detail="Cannot create leave request for another user.")
+        raise HTTPException(status_code=403, detail="user_id in payload must match authenticated user.")
     return crud.create_user_leave(db=db, leave=leave_in, user_id=current_user.id)
 
 @r.get("/leaves", response_model=t.List[schemas.Leave])
@@ -88,3 +88,88 @@ async def delete_leave_request(
         raise HTTPException(status_code=404, detail="Leave request not found or not owned by user")
 
     return crud.delete_leave(db=db, leave_id=leave_id, user_id=current_user.id)
+
+
+# Admin Endpoints for managing leaves
+
+@r.post("/admin/leaves", response_model=schemas.Leave, status_code=201, tags=["admin"])
+async def admin_create_leave_for_user(
+    leave_in: schemas.LeaveCreate, # Contains user_id for target user
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Create a new leave request for a specified user.
+    The user_id of the target user must be provided in the leave_in payload.
+    """
+    # Optional: Validate if user_id in leave_in exists
+    user = crud.get_user(db, leave_in.user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User with id {leave_in.user_id} not found.")
+    # The user_id from the payload (leave_in.user_id) is passed to crud.create_user_leave
+    return crud.create_user_leave(db=db, leave=leave_in, user_id=leave_in.user_id)
+
+@r.get("/admin/users/{user_id}/leaves", response_model=t.List[schemas.Leave], tags=["admin"])
+async def admin_get_user_leave_requests(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+    skip: int = 0,
+    limit: int = Query(default=100, lte=100),
+):
+    """
+    Admin: Get all leave requests for a specific user.
+    """
+    user = crud.get_user(db, user_id) # Validate user exists
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User with id {user_id} not found.")
+    return crud.get_user_leaves(db=db, user_id=user_id, skip=skip, limit=limit)
+
+@r.get("/admin/leaves/{leave_id}", response_model=schemas.Leave, tags=["admin"])
+async def admin_get_leave_request_by_id(
+    leave_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Get a specific leave request by its ID.
+    """
+    leave = crud.get_leave_by_id_admin(db=db, leave_id=leave_id)
+    if not leave:
+        raise HTTPException(status_code=404, detail="Leave request not found")
+    return leave
+
+@r.put("/admin/leaves/{leave_id}", response_model=schemas.Leave, tags=["admin"])
+async def admin_update_leave_request(
+    leave_id: int,
+    leave_in: schemas.LeaveEdit,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Update a specific leave request by its ID.
+    """
+    # crud.update_leave_admin will fetch the leave by ID and update it.
+    # It also handles the case where the leave doesn't exist.
+    # Note: LeaveEdit schema does not (and should not) contain user_id to change ownership.
+    # If changing user_id was a requirement, the schema and logic would need adjustment.
+    updated_leave = crud.update_leave_admin(db=db, leave_id=leave_id, leave_update=leave_in)
+    if not updated_leave: # Should be handled by HTTPException in crud if not found
+        raise HTTPException(status_code=404, detail="Leave request not found or failed to update")
+    return updated_leave
+
+@r.delete("/admin/leaves/{leave_id}", response_model=schemas.Leave, tags=["admin"])
+async def admin_delete_leave_request(
+    leave_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Delete a specific leave request by its ID.
+    """
+    # crud.delete_leave_admin will fetch the leave by ID and delete it.
+    # It also handles the case where the leave doesn't exist.
+    deleted_leave = crud.delete_leave_admin(db=db, leave_id=leave_id)
+    if not deleted_leave: # Should be handled by HTTPException in crud if not found
+        raise HTTPException(status_code=404, detail="Leave request not found or failed to delete")
+    return deleted_leave

--- a/new_project_jules/backend/app/api/api_v1/routers/wfh.py
+++ b/new_project_jules/backend/app/api/api_v1/routers/wfh.py
@@ -4,13 +4,15 @@ import typing as t
 
 from app.db.session import get_db
 from app.db import crud, schemas
-from app.core.auth import get_current_active_user
+from app.core.auth import get_current_active_user, get_current_active_superuser
 from app.db.models import User
 
 wfh_router = r = APIRouter()
 
+# Regular user endpoints
+
 @r.post("/wfh", response_model=schemas.WFH, status_code=201)
-async def create_wfh_request(
+async def create_wfh_request_for_self(
     wfh_in: schemas.WFHCreate,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -19,7 +21,7 @@ async def create_wfh_request(
     Create a new WFH request for the current user.
     """
     if wfh_in.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Cannot create WFH request for another user.")
+        raise HTTPException(status_code=403, detail="user_id in payload must match authenticated user.")
     return crud.create_user_wfh(db=db, wfh=wfh_in, user_id=current_user.id)
 
 @r.get("/wfh", response_model=t.List[schemas.WFH])
@@ -81,3 +83,81 @@ async def delete_wfh_request(
         raise HTTPException(status_code=404, detail="WFH request not found or not owned by user")
 
     return crud.delete_wfh(db=db, wfh_id=wfh_id, user_id=current_user.id)
+
+
+# Admin Endpoints for managing WFH requests
+
+@r.post("/admin/wfh", response_model=schemas.WFH, status_code=201, tags=["admin"])
+async def admin_create_wfh_for_user(
+    wfh_in: schemas.WFHCreate, # Contains user_id for target user
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Create a new WFH request for a specified user.
+    The user_id of the target user must be provided in the wfh_in payload.
+    """
+    user = crud.get_user(db, wfh_in.user_id) # Validate user exists
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User with id {wfh_in.user_id} not found.")
+    # The user_id from the payload (wfh_in.user_id) is passed to crud.create_user_wfh
+    return crud.create_user_wfh(db=db, wfh=wfh_in, user_id=wfh_in.user_id)
+
+@r.get("/admin/users/{user_id}/wfh", response_model=t.List[schemas.WFH], tags=["admin"])
+async def admin_get_user_wfh_requests(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+    skip: int = 0,
+    limit: int = Query(default=100, lte=100),
+):
+    """
+    Admin: Get all WFH requests for a specific user.
+    """
+    user = crud.get_user(db, user_id) # Validate user exists
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User with id {user_id} not found.")
+    return crud.get_user_wfhs(db=db, user_id=user_id, skip=skip, limit=limit)
+
+@r.get("/admin/wfh/{wfh_id}", response_model=schemas.WFH, tags=["admin"])
+async def admin_get_wfh_request_by_id(
+    wfh_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Get a specific WFH request by its ID.
+    """
+    wfh = crud.get_wfh_by_id_admin(db=db, wfh_id=wfh_id)
+    if not wfh:
+        raise HTTPException(status_code=404, detail="WFH request not found")
+    return wfh
+
+@r.put("/admin/wfh/{wfh_id}", response_model=schemas.WFH, tags=["admin"])
+async def admin_update_wfh_request(
+    wfh_id: int,
+    wfh_in: schemas.WFHEdit,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Update a specific WFH request by its ID.
+    """
+    updated_wfh = crud.update_wfh_admin(db=db, wfh_id=wfh_id, wfh_update=wfh_in)
+    if not updated_wfh: # Should be handled by HTTPException in crud if not found
+        raise HTTPException(status_code=404, detail="WFH request not found or failed to update")
+    return updated_wfh
+
+@r.delete("/admin/wfh/{wfh_id}", response_model=schemas.WFH, tags=["admin"])
+async def admin_delete_wfh_request(
+    wfh_id: int,
+    db: Session = Depends(get_db),
+    current_superuser: User = Depends(get_current_active_superuser),
+):
+    """
+    Admin: Delete a specific WFH request by its ID.
+    """
+    deleted_wfh = crud.delete_wfh_admin(db=db, wfh_id=wfh_id)
+    if not deleted_wfh: # Should be handled by HTTPException in crud if not found
+        raise HTTPException(status_code=404, detail="WFH request not found or failed to delete")
+    return deleted_wfh

--- a/new_project_jules/backend/app/db/crud.py
+++ b/new_project_jules/backend/app/db/crud.py
@@ -48,11 +48,19 @@ def get_leave(db: Session, leave_id: int, user_id: int):
 def get_user_leaves(db: Session, user_id: int, skip: int = 0, limit: int = 100) -> t.List[schemas.Leave]:
     return db.query(models.Leave).filter(models.Leave.user_id == user_id).offset(skip).limit(limit).all()
 
+# Admin CRUD function to get any leave by ID without user_id check
+def get_leave_by_id_admin(db: Session, leave_id: int):
+    leave = db.query(models.Leave).filter(models.Leave.id == leave_id).first()
+    if not leave:
+        raise HTTPException(status_code=404, detail="Leave request not found")
+    return leave
+
 def create_user_leave(db: Session, leave: schemas.LeaveCreate, user_id: int):
-    # Prioritize user_id from parameter (authenticated user)
-    # leave.user_id from schema should have been validated against this in API layer
-    leave_data = leave.model_dump(exclude_unset=True, exclude={'user_id'}) # Exclude user_id from the dump
-    db_leave = models.Leave(**leave_data, user_id=user_id) # Pass user_id explicitly
+    # user_id parameter is authoritative.
+    # For regular users, API layer sets this to current_user.id and validates leave.user_id against it.
+    # For admin, API layer sets this to leave.user_id from payload.
+    leave_data = leave.model_dump(exclude={'user_id'}) # Exclude user_id from model dump, as it's passed directly
+    db_leave = models.Leave(**leave_data, user_id=user_id)
     db.add(db_leave)
     db.commit()
     db.refresh(db_leave)
@@ -70,8 +78,26 @@ def update_leave(db: Session, leave_id: int, leave_update: schemas.LeaveEdit, us
     db.refresh(db_leave)
     return db_leave
 
+def update_leave_admin(db: Session, leave_id: int, leave_update: schemas.LeaveEdit):
+    db_leave = get_leave_by_id_admin(db, leave_id) # Use the admin getter, no user_id check
+    update_data = leave_update.model_dump(exclude_unset=True)
+
+    for key, value in update_data.items():
+        setattr(db_leave, key, value)
+
+    db.add(db_leave)
+    db.commit()
+    db.refresh(db_leave)
+    return db_leave
+
 def delete_leave(db: Session, leave_id: int, user_id: int):
     db_leave = get_leave(db, leave_id, user_id) # Ensures user owns the leave
+    db.delete(db_leave)
+    db.commit()
+    return db_leave
+
+def delete_leave_admin(db: Session, leave_id: int):
+    db_leave = get_leave_by_id_admin(db, leave_id) # Use the admin getter, no user_id check
     db.delete(db_leave)
     db.commit()
     return db_leave
@@ -109,6 +135,29 @@ def update_wfh(db: Session, wfh_id: int, wfh_update: schemas.WFHEdit, user_id: i
 
 def delete_wfh(db: Session, wfh_id: int, user_id: int):
     db_wfh = get_wfh(db, wfh_id, user_id) # Ensures user owns the wfh
+    db.delete(db_wfh)
+    db.commit()
+    return db_wfh
+
+# Admin WFH CRUD functions
+def get_wfh_by_id_admin(db: Session, wfh_id: int):
+    wfh = db.query(models.WFH).filter(models.WFH.id == wfh_id).first()
+    if not wfh:
+        raise HTTPException(status_code=404, detail="WFH request not found")
+    return wfh
+
+def update_wfh_admin(db: Session, wfh_id: int, wfh_update: schemas.WFHEdit):
+    db_wfh = get_wfh_by_id_admin(db, wfh_id) # Use admin getter
+    update_data = wfh_update.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(db_wfh, key, value)
+    db.add(db_wfh)
+    db.commit()
+    db.refresh(db_wfh)
+    return db_wfh
+
+def delete_wfh_admin(db: Session, wfh_id: int):
+    db_wfh = get_wfh_by_id_admin(db, wfh_id) # Use admin getter
     db.delete(db_wfh)
     db.commit()
     return db_wfh

--- a/new_project_jules/frontend/pages/AdminLeaveWFHManagementPage.tsx
+++ b/new_project_jules/frontend/pages/AdminLeaveWFHManagementPage.tsx
@@ -1,0 +1,236 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box, Typography, Select, MenuItem, FormControl, InputLabel,
+  CircularProgress, Grid, Paper, Button, SelectChangeEvent
+} from '@mui/material';
+import { DataGrid, GridColDef, GridRowsProp } from '@mui/x-data-grid';
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+// TODO: Define types for User, Leave, WFH based on backend schemas
+interface User {
+  id: number;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+interface Leave {
+  id: number;
+  from_date: string;
+  to_date: string;
+  leave_type: string;
+  status: string;
+  comments?: string;
+  num_days: number;
+  user_id: number;
+}
+
+interface WFH {
+  id: number;
+  from_date: string;
+  to_date: string;
+  status: string;
+  comments?: string;
+  num_days: number;
+  user_id: number;
+}
+
+const API_BASE_URL = 'http://localhost:8000/api/v1'; // Assuming API is on port 8000
+
+const leaveColumns: GridColDef[] = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'leave_type', headerName: 'Type', width: 130 },
+  { field: 'from_date', headerName: 'From', width: 120, type: 'date', valueGetter: params => new Date(params.value) },
+  { field: 'to_date', headerName: 'To', width: 120, type: 'date', valueGetter: params => new Date(params.value) },
+  { field: 'num_days', headerName: 'Days', width: 90, type: 'number' },
+  { field: 'status', headerName: 'Status', width: 120 },
+  { field: 'comments', headerName: 'Comments', width: 200 },
+  {
+    field: 'actions',
+    headerName: 'Actions',
+    width: 150,
+    sortable: false,
+    renderCell: (params) => (
+      <>
+        <Button size="small" onClick={() => console.log('Edit leave', params.row)}><EditIcon /></Button>
+        <Button size="small" onClick={() => console.log('Delete leave', params.row)}><DeleteIcon /></Button>
+      </>
+    ),
+  },
+];
+
+const wfhColumns: GridColDef[] = [
+  { field: 'id', headerName: 'ID', width: 70 },
+  { field: 'from_date', headerName: 'From', width: 120, type: 'date', valueGetter: params => new Date(params.value) },
+  { field: 'to_date', headerName: 'To', width: 120, type: 'date', valueGetter: params => new Date(params.value) },
+  { field: 'num_days', headerName: 'Days', width: 90, type: 'number' },
+  { field: 'status', headerName: 'Status', width: 120 },
+  { field: 'comments', headerName: 'Comments', width: 200 },
+  {
+    field: 'actions',
+    headerName: 'Actions',
+    width: 150,
+    sortable: false,
+    renderCell: (params) => (
+      <>
+        <Button size="small" onClick={() => console.log('Edit WFH', params.row)}><EditIcon /></Button>
+        <Button size="small" onClick={() => console.log('Delete WFH', params.row)}><DeleteIcon /></Button>
+      </>
+    ),
+  },
+];
+
+
+export default function AdminLeaveWFHManagementPage() {
+  const [users, setUsers] = useState<User[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string>('');
+  const [userLeaves, setUserLeaves] = useState<GridRowsProp>([]);
+  const [userWFHs, setUserWFHs] = useState<GridRowsProp>([]);
+
+  const [loadingUsers, setLoadingUsers] = useState<boolean>(false);
+  const [loadingDetails, setLoadingDetails] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const token = localStorage.getItem('accessToken');
+
+  // Fetch all users
+  useEffect(() => {
+    const fetchUsers = async () => {
+      setLoadingUsers(true);
+      setError(null);
+      try {
+        const response = await fetch(`${API_BASE_URL}/users`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!response.ok) throw new Error(`Failed to fetch users: ${response.statusText}`);
+        const data: User[] = await response.json();
+        setUsers(data);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoadingUsers(false);
+      }
+    };
+    if (token) {
+      fetchUsers();
+    } else {
+      setError("Authentication token not found.");
+    }
+  }, [token]);
+
+  // Fetch leaves and WFH for selected user
+  useEffect(() => {
+    if (!selectedUserId || !token) {
+      setUserLeaves([]);
+      setUserWFHs([]);
+      return;
+    }
+
+    const fetchUserDetails = async () => {
+      setLoadingDetails(true);
+      setError(null);
+      try {
+        // Fetch Leaves
+        const leavesResponse = await fetch(`${API_BASE_URL}/admin/users/${selectedUserId}/leaves`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!leavesResponse.ok) throw new Error(`Failed to fetch leaves: ${leavesResponse.statusText}`);
+        const leavesData: Leave[] = await leavesResponse.json();
+        setUserLeaves(leavesData.map(l => ({ ...l, from_date: new Date(l.from_date), to_date: new Date(l.to_date) })));
+
+        // Fetch WFH
+        const wfhResponse = await fetch(`${API_BASE_URL}/admin/users/${selectedUserId}/wfh`, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+        if (!wfhResponse.ok) throw new Error(`Failed to fetch WFH: ${wfhResponse.statusText}`);
+        const wfhData: WFH[] = await wfhResponse.json();
+        setUserWFHs(wfhData.map(w => ({ ...w, from_date: new Date(w.from_date), to_date: new Date(w.to_date) })));
+
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setLoadingDetails(false);
+      }
+    };
+
+    fetchUserDetails();
+  }, [selectedUserId, token]);
+
+  const handleUserChange = (event: SelectChangeEvent<string>) => {
+    setSelectedUserId(event.target.value);
+  };
+
+  // Placeholder for Add/Edit/Delete Modals and functions
+  // TODO: Implement Modals for Add/Edit Leave and WFH
+  // TODO: Implement Delete confirmation and logic
+
+  if (!token) {
+    return <Typography color="error">Not authenticated. Please login.</Typography>;
+  }
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
+        Admin - Manage Employee Leaves & WFH
+      </Typography>
+
+      {loadingUsers && <CircularProgress />}
+      {error && <Typography color="error" sx={{ mb: 2 }}>Error: {error}</Typography>}
+
+      <FormControl fullWidth sx={{ mb: 3 }}>
+        <InputLabel id="select-user-label">Select User</InputLabel>
+        <Select
+          labelId="select-user-label"
+          id="select-user"
+          value={selectedUserId}
+          label="Select User"
+          onChange={handleUserChange}
+          disabled={loadingUsers || users.length === 0}
+        >
+          <MenuItem value=""><em>None</em></MenuItem>
+          {users.map((user) => (
+            <MenuItem key={user.id} value={String(user.id)}>
+              {user.first_name || user.last_name ? `${user.first_name || ''} ${user.last_name || ''}`.trim() : user.email} ({user.id})
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+
+      {selectedUserId && (
+        loadingDetails ? <CircularProgress sx={{mt: 2}} /> : (
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <Paper sx={{ p: 2 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                  <Typography variant="h6">Leave Requests</Typography>
+                  <Button variant="contained" startIcon={<AddCircleOutlineIcon />} onClick={() => console.log("Add Leave for user:", selectedUserId)}>
+                    Add Leave
+                  </Button>
+                </Box>
+                <Box sx={{ height: 300, width: '100%' }}>
+                  <DataGrid rows={userLeaves} columns={leaveColumns} pageSizeOptions={[5]} autoPageSize />
+                </Box>
+              </Paper>
+            </Grid>
+
+            <Grid item xs={12}>
+              <Paper sx={{ p: 2, mt: 2 }}>
+                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                  <Typography variant="h6">Work From Home Requests</Typography>
+                  <Button variant="contained" startIcon={<AddCircleOutlineIcon />} onClick={() => console.log("Add WFH for user:", selectedUserId)}>
+                    Add WFH
+                  </Button>
+                </Box>
+                <Box sx={{ height: 300, width: '100%' }}>
+                  <DataGrid rows={userWFHs} columns={wfhColumns} pageSizeOptions={[5]} autoPageSize />
+                </Box>
+              </Paper>
+            </Grid>
+          </Grid>
+        )
+      )}
+    </Box>
+  );
+}

--- a/new_project_jules/frontend/src/App.tsx
+++ b/new_project_jules/frontend/src/App.tsx
@@ -12,16 +12,29 @@ import LeavesPage from '../pages/LeavesPage'; // New leaves page
 import LeaveRequestsPage from '../pages/LeaveRequestsPage'; // New Leave Requests page
 import WorkFromHomeRequestsPage from '../pages/WorkFromHomeRequestsPage'; // New WFH Requests page
 import AttendancePage from '../pages/attendance';
+import AdminLeaveWFHManagementPage from '../pages/AdminLeaveWFHManagementPage'; // Import the new admin page
 
-// Basic ProtectedRoute component
-const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
-  const isAuthenticated = localStorage.getItem('isAuthenticated');
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requireSuperuser?: boolean;
+}
+
+const ProtectedRoute = ({ children, requireSuperuser = false }: ProtectedRouteProps) => {
+  const isAuthenticated = localStorage.getItem('isAuthenticated') === 'true';
+  const isSuperuser = localStorage.getItem('is_superuser') === 'true';
+
   if (!isAuthenticated) {
-    // Navigate component should be used within a Routes context or have a navigator from context
-    // For simplicity here, we'll assume this will be part of a <Routes> setup
     return <Navigate to="/login" replace />;
   }
-  return <>{children}</>; // Use fragment if children is ReactNode
+
+  if (requireSuperuser && !isSuperuser) {
+    // Optionally, redirect to a 'Not Authorized' page or back to home
+    // For now, redirecting to home, or you could show a message.
+    alert('You are not authorized to view this page.'); // Simple alert for now
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
 };
 
 function App() {
@@ -82,6 +95,13 @@ function App() {
           </ProtectedRoute>
         } />
         {/* Add other routes here */}
+        <Route path="/admin/manage-records" element={
+          <ProtectedRoute requireSuperuser={true}>
+            <DashboardLayout>
+              <AdminLeaveWFHManagementPage />
+            </DashboardLayout>
+          </ProtectedRoute>
+        } />
       </Routes>
     </Router>
   );

--- a/new_project_jules/frontend/src/DashboardLayout.tsx
+++ b/new_project_jules/frontend/src/DashboardLayout.tsx
@@ -42,6 +42,7 @@ import ReportProblemIcon from '@mui/icons-material/ReportProblem'; // For "Confl
 import RefreshIcon from '@mui/icons-material/Refresh';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings'; // Icon for Admin Page
 
 const drawerWidth = 240;
 
@@ -140,13 +141,19 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const [open, setOpen] = useState(true); // Drawer is open by default
   const [selectedItem, setSelectedItem] = useState('Dashboard'); // State for selected item
   const [openSubmenus, setOpenSubmenus] = useState<Record<string, boolean>>({}); // State for submenus
+  const [isSuperuser, setIsSuperuser] = useState(false);
+
+  useEffect(() => {
+    const superuserStatus = localStorage.getItem('is_superuser') === 'true';
+    setIsSuperuser(superuserStatus);
+  }, []);
 
   const handleDrawerToggle = () => {
     setOpen(!open);
   };
 
   // Define menu items with paths
-  const menuItems = [
+  const baseMenuItems = [
     { text: 'Dashboard', icon: <DashboardIcon />, path: '/' },
     { text: 'IV Forum', icon: <ForumIcon />, path: '/iv-forum' },
     {
@@ -175,6 +182,14 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
     },
   ];
 
+  const adminMenuItem = {
+    text: 'Admin Management',
+    icon: <AdminPanelSettingsIcon />,
+    path: '/admin/manage-records',
+  };
+
+  const menuItems = isSuperuser ? [...baseMenuItems, adminMenuItem] : baseMenuItems;
+
   const handleListItemClick = (text: string, path?: string, isParent: boolean = false) => {
     if (path && !isParent) { // Navigable child or standalone item
       setSelectedItem(text);
@@ -187,7 +202,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
         setSelectedItem(text);
         navigate(path);
         // Also toggle submenu if it has children
-        if (menuItems.find(item => item.text === text)?.children) {
+        if (baseMenuItems.find(item => item.text === text)?.children) { // Check baseMenuItems for children logic
             setOpenSubmenus(prev => ({ ...prev, [text]: !prev[text] }));
         }
     }


### PR DESCRIPTION
Backend:
- Added new admin-specific API endpoints for leaves and WFH requests.
  - Superusers can now create, view, update, and delete leaves/WFH for any user.
- Added corresponding admin CRUD operations in db.crud.
- Ensured existing user-specific endpoints remain unchanged.

Frontend:
- Created AdminLeaveWFHManagementPage.tsx:
  - Allows superusers to select an employee.
  - Displays leave and WFH requests for the selected employee.
  - Placeholder buttons for add/edit/delete actions.
- Updated Login.tsx to fetch user details (including is_superuser) and store them in localStorage.
- Modified ProtectedRoute to check for superuser privileges.
- Updated DashboardLayout to conditionally display an "Admin Management" link in the sidebar for superusers.