### PR TITLE
Refactor: Remove /users/me call from login flow

### DIFF
--- a/new_project_jules/frontend/package-lock.json
+++ b/new_project_jules/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@tanstack/react-query": "^5.81.2",
         "date-fns": "^3.6.0",
         "formik": "^2.4.6",
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
@@ -3907,6 +3908,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/new_project_jules/frontend/package.json
+++ b/new_project_jules/frontend/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.81.2",
     "date-fns": "^3.6.0",
     "formik": "^2.4.6",
+    "jwt-decode": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",

--- a/new_project_jules/frontend/src/Login.tsx
+++ b/new_project_jules/frontend/src/Login.tsx
@@ -1,13 +1,22 @@
 import { LockOutlined } from '@mui/icons-material';
 import { Avatar, Box, Button, Container, CssBaseline, Grid, Link, TextField, Typography } from '@mui/material';
-import { Formik, Form, Field, ErrorMessage, FormikHelpers } from 'formik'; // Import FormikHelpers
+import { Formik, Form, Field, ErrorMessage, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import { useNavigate } from 'react-router-dom';
+import { jwtDecode } from 'jwt-decode'; // Import jwt-decode
 
 // Define the type for form values
 interface LoginValues {
   username: string;
   password: string;
+}
+
+// Define the type for the decoded token
+interface DecodedToken {
+  sub: string;
+  permissions: string;
+  exp: number;
+  // Add other claims if present in your token
 }
 
 const LoginSchema = Yup.object().shape({
@@ -20,6 +29,10 @@ const Login = () => {
 
   const handleSubmit = async (values: LoginValues, { setSubmitting, setFieldError }: FormikHelpers<LoginValues>) => {
     setSubmitting(true);
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('isAuthenticated');
+    localStorage.removeItem('is_superuser');
+
     try {
       const formData = new FormData();
       formData.append('username', values.username);
@@ -34,48 +47,49 @@ const Login = () => {
       if (!tokenResponse.ok) {
         const errorData = await tokenResponse.json();
         setFieldError('username', errorData.detail || 'Login failed: Invalid credentials');
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('isAuthenticated');
-        localStorage.removeItem('is_superuser');
         return; // Exit if token request fails
       }
 
       const tokenData = await tokenResponse.json();
       const accessToken = tokenData.access_token;
+
+      if (!accessToken) {
+        setFieldError('username', 'Login failed: No access token received.');
+        return;
+      }
       localStorage.setItem('accessToken', accessToken);
 
-      // Step 2: Fetch user details using the token
-      const userDetailsResponse = await fetch('http://localhost:8000/api/v1/users/me', { // Main API endpoint
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${accessToken}`,
-        },
-      });
+      // Step 2: Decode the token to get user permissions
+      try {
+        const decodedToken = jwtDecode<DecodedToken>(accessToken);
+        const permissions = decodedToken.permissions;
+        const isSuperuser = permissions === 'admin';
 
-      if (!userDetailsResponse.ok) {
-        const errorData = await userDetailsResponse.json();
-        console.error('Failed to fetch user details:', errorData.detail);
-        // Even if user details fail, token might be valid but further action might be needed.
-        // For now, let's treat this as a partial success but flag that user details couldn't be fetched.
-        // Or, treat as a full failure for security/consistency.
-        setFieldError('username', 'Login successful, but failed to fetch user details.');
-        // Decide if we should clear the token or allow login with partial data.
-        // For now, clearing stored items for safety if user details are crucial.
+        localStorage.setItem('isAuthenticated', 'true');
+        localStorage.setItem('is_superuser', String(isSuperuser));
+
+        navigate('/'); // Navigate to home page
+      } catch (decodeError) {
+        console.error('Failed to decode token:', decodeError);
+        setFieldError('username', 'Login successful, but failed to process user information.');
+        // Clear stored items if token decoding fails, as we can't trust the session
         localStorage.removeItem('accessToken');
         localStorage.removeItem('isAuthenticated');
         localStorage.removeItem('is_superuser');
-        return;
       }
-
-      const userData = await userDetailsResponse.json();
-      localStorage.setItem('isAuthenticated', 'true');
-      localStorage.setItem('is_superuser', String(userData.is_superuser)); // Store as string 'true' or 'false'
-
-      navigate('/'); // Navigate to home page
 
     } catch (error) {
       console.error('Login process error:', error);
-      setFieldError('username', 'An unexpected error occurred during login. Please try again.');
+      // Check if error is an instance of Error to safely access message property
+      let errorMessage = 'An unexpected error occurred during login. Please try again.';
+      if (error instanceof Error) {
+        // Potentially more specific error handling based on error.name or error.message
+        if (error.message.includes('Failed to fetch')) {
+            errorMessage = 'Cannot connect to the server. Please check your network connection.';
+        }
+      }
+      setFieldError('username', errorMessage);
+      // Ensure localStorage is cleaned up on error regardless of where it occurs in try block
       localStorage.removeItem('accessToken');
       localStorage.removeItem('isAuthenticated');
       localStorage.removeItem('is_superuser');
@@ -106,7 +120,7 @@ const Login = () => {
           validationSchema={LoginSchema}
           onSubmit={handleSubmit}
         >
-          {({ isSubmitting }: { isSubmitting: boolean }) => ( // Explicitly type isSubmitting
+          {({ isSubmitting }) => ( // isSubmitting type is inferred by Formik
             <Form>
               <Field
                 as={TextField}
@@ -119,6 +133,7 @@ const Login = () => {
                 autoComplete="username"
                 autoFocus
                 helperText={<ErrorMessage name="username" />}
+                error={!!(<ErrorMessage name="username" />)}
               />
               <Field
                 as={TextField}
@@ -131,6 +146,7 @@ const Login = () => {
                 id="password"
                 autoComplete="current-password"
                 helperText={<ErrorMessage name="password" />}
+                error={!!(<ErrorMessage name="password" />)}
               />
               <Button
                 type="submit"
@@ -141,13 +157,13 @@ const Login = () => {
               >
                 Sign In
               </Button>
-              <Grid container justifyContent="space-between"> {/* Added justifyContent */}
-                <Grid item xs> {/* Takes available space */}
+              <Grid container justifyContent="space-between">
+                <Grid item xs>
                   <Link href="#" variant="body2">
                     Forgot password?
                   </Link>
                 </Grid>
-                <Grid item> {/* Takes content width */}
+                <Grid item>
                   <Link href="#" variant="body2">
                     {"Don't have an account? Sign Up"}
                   </Link>


### PR DESCRIPTION
- Modified Login.tsx to remove the API call to /api/v1/users/me.
- User's `is_superuser` status is now determined by decoding the `permissions` claim from the JWT access token on the frontend using `jwt-decode`.
- Updated localStorage logic to reflect the new way of obtaining `is_superuser`.
- Verified backend OAuth2 usage, confirming adherence to FastAPI best practices with OAuth2PasswordBearer.