### PR TITLE
Fix: Allow None for first_name and last_name in User model

### DIFF
--- a/new_project_jules/backend/app/db/schemas.py
+++ b/new_project_jules/backend/app/db/schemas.py
@@ -6,8 +6,8 @@ class UserBase(BaseModel):
     email: str
     is_active: bool = True
     is_superuser: bool = False
-    first_name: str = ""
-    last_name: str = ""
+    first_name: t.Optional[str] = None
+    last_name: t.Optional[str] = None
 
 
 class UserOut(UserBase):


### PR DESCRIPTION
This resolves a Pydantic validation error on the users/me endpoint where these fields could be None, but the schema expected strings. Changed UserBase to use t.Optional[str] = None for first_name and last_name.