### PR TITLE
Fix: Resolve 401 error on Leave Requests page and implement Admin Add…

### DIFF
--- a/new_project_jules/frontend/pages/AdminLeaveWFHManagementPage.tsx
+++ b/new_project_jules/frontend/pages/AdminLeaveWFHManagementPage.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import {
   Box, Typography, Select, MenuItem, FormControl, InputLabel,
-  CircularProgress, Grid, Paper, Button, SelectChangeEvent
+  CircularProgress, Grid, Paper, Button, SelectChangeEvent, Modal,
+  TextField, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle
 } from '@mui/material';
 import { DataGrid, GridColDef, GridRowsProp } from '@mui/x-data-grid';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 
@@ -92,8 +95,53 @@ export default function AdminLeaveWFHManagementPage() {
   const [loadingUsers, setLoadingUsers] = useState<boolean>(false);
   const [loadingDetails, setLoadingDetails] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+
+
+  const [addLeaveModalOpen, setAddLeaveModalOpen] = useState(false);
+  const [newLeaveData, setNewLeaveData] = useState({
+    leave_type: '',
+    start_date: null as Date | null,
+    end_date: null as Date | null,
+    reason: '',
+  });
 
   const token = localStorage.getItem('accessToken');
+
+  const fetchUserLeaves = async (userId: string) => {
+    if (!token || !userId) return;
+    setLoadingDetails(true);
+    try {
+      const leavesResponse = await fetch(`${API_BASE_URL}/admin/users/${userId}/leaves`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!leavesResponse.ok) throw new Error(`Failed to fetch leaves: ${leavesResponse.statusText}`);
+      const leavesData: Leave[] = await leavesResponse.json();
+      setUserLeaves(leavesData.map(l => ({ ...l, from_date: new Date(l.from_date), to_date: new Date(l.to_date) })));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoadingDetails(false);
+    }
+  };
+
+  const fetchUserWFHs = async (userId: string) => {
+    if (!token || !userId) return;
+    // setLoadingDetails(true); // Assuming this is handled by a combined loading state or called after leaves
+    try {
+      const wfhResponse = await fetch(`${API_BASE_URL}/admin/users/${userId}/wfh`, {
+        headers: { 'Authorization': `Bearer ${token}` },
+      });
+      if (!wfhResponse.ok) throw new Error(`Failed to fetch WFH: ${wfhResponse.statusText}`);
+      const wfhData: WFH[] = await wfhResponse.json();
+      setUserWFHs(wfhData.map(w => ({ ...w, from_date: new Date(w.from_date), to_date: new Date(w.to_date) })));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      // setLoadingDetails(false);
+    }
+  };
+
 
   // Fetch all users
   useEffect(() => {
@@ -127,43 +175,94 @@ export default function AdminLeaveWFHManagementPage() {
       setUserWFHs([]);
       return;
     }
+    setLoadingDetails(true); // Set loading before starting fetches
+    setError(null); // Clear previous errors
 
-    const fetchUserDetails = async () => {
-      setLoadingDetails(true);
-      setError(null);
-      try {
-        // Fetch Leaves
-        const leavesResponse = await fetch(`${API_BASE_URL}/admin/users/${selectedUserId}/leaves`, {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (!leavesResponse.ok) throw new Error(`Failed to fetch leaves: ${leavesResponse.statusText}`);
-        const leavesData: Leave[] = await leavesResponse.json();
-        setUserLeaves(leavesData.map(l => ({ ...l, from_date: new Date(l.from_date), to_date: new Date(l.to_date) })));
+    Promise.all([
+      fetchUserLeaves(selectedUserId),
+      fetchUserWFHs(selectedUserId)
+    ]).catch(e => {
+      // This catch might be redundant if errors are handled within fetchUserLeaves/WFHs
+      // and set via setError directly.
+      setError(e instanceof Error ? e.message : String(e));
+    }).finally(() => {
+      setLoadingDetails(false); // Clear loading after all promises settle
+    });
 
-        // Fetch WFH
-        const wfhResponse = await fetch(`${API_BASE_URL}/admin/users/${selectedUserId}/wfh`, {
-          headers: { 'Authorization': `Bearer ${token}` },
-        });
-        if (!wfhResponse.ok) throw new Error(`Failed to fetch WFH: ${wfhResponse.statusText}`);
-        const wfhData: WFH[] = await wfhResponse.json();
-        setUserWFHs(wfhData.map(w => ({ ...w, from_date: new Date(w.from_date), to_date: new Date(w.to_date) })));
-
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-      } finally {
-        setLoadingDetails(false);
-      }
-    };
-
-    fetchUserDetails();
-  }, [selectedUserId, token]);
+  }, [selectedUserId, token]); // Removed fetchUserLeaves, fetchUserWFHs from deps as they are stable
 
   const handleUserChange = (event: SelectChangeEvent<string>) => {
     setSelectedUserId(event.target.value);
   };
 
-  // Placeholder for Add/Edit/Delete Modals and functions
-  // TODO: Implement Modals for Add/Edit Leave and WFH
+  const handleOpenAddLeaveModal = () => {
+    setNewLeaveData({ // Reset form
+      leave_type: '',
+      start_date: null,
+      end_date: null,
+      reason: '',
+    });
+    setSubmissionError(null); // Clear previous submission errors
+    setAddLeaveModalOpen(true);
+  };
+
+  const handleCloseAddLeaveModal = () => {
+    setAddLeaveModalOpen(false);
+  };
+
+  const handleAddLeaveChange = (event: SelectChangeEvent<string> | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setNewLeaveData(prev => ({ ...prev, [name!]: value }));
+  };
+
+  const handleAddLeaveDateChange = (name: 'start_date' | 'end_date', date: Date | null) => {
+    setNewLeaveData(prev => ({ ...prev, [name]: date }));
+  };
+
+  const handleAddLeaveSubmit = async () => {
+    if (!selectedUserId || !token || !newLeaveData.start_date || !newLeaveData.end_date || !newLeaveData.leave_type) {
+      setSubmissionError("User, leave type, start date, and end date are required.");
+      return;
+    }
+    setSubmissionError(null);
+
+    // Format dates to YYYY-MM-DD string
+    const formatDate = (date: Date) => date.toISOString().split('T')[0];
+
+    const payload = {
+      user_id: parseInt(selectedUserId),
+      leave_type: newLeaveData.leave_type,
+      start_date: formatDate(newLeaveData.start_date),
+      end_date: formatDate(newLeaveData.end_date),
+      reason: newLeaveData.reason || null, // Ensure reason is null if empty, not ""
+      status: "pending", // Default status
+    };
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/admin/leaves`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.detail || `Failed to add leave: ${response.statusText}`);
+      }
+
+      // Success
+      handleCloseAddLeaveModal();
+      await fetchUserLeaves(selectedUserId); // Refresh leaves for the current user
+    } catch (e) {
+      setSubmissionError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+
+  // TODO: Implement Modals for Edit Leave and WFH
   // TODO: Implement Delete confirmation and logic
 
   if (!token) {
@@ -171,15 +270,16 @@ export default function AdminLeaveWFHManagementPage() {
   }
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
-        Admin - Manage Employee Leaves & WFH
-      </Typography>
+    <LocalizationProvider dateAdapter={AdapterDateFns}>
+      <Box sx={{ p: 3 }}>
+        <Typography variant="h4" gutterBottom sx={{ mb: 3 }}>
+          Admin - Manage Employee Leaves & WFH
+        </Typography>
 
-      {loadingUsers && <CircularProgress />}
-      {error && <Typography color="error" sx={{ mb: 2 }}>Error: {error}</Typography>}
+        {loadingUsers && <CircularProgress />}
+        {error && <Typography color="error" sx={{ mb: 2 }}>Error: {error}</Typography>}
 
-      <FormControl fullWidth sx={{ mb: 3 }}>
+        <FormControl fullWidth sx={{ mb: 3 }}>
         <InputLabel id="select-user-label">Select User</InputLabel>
         <Select
           labelId="select-user-label"
@@ -205,7 +305,7 @@ export default function AdminLeaveWFHManagementPage() {
               <Paper sx={{ p: 2 }}>
                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                   <Typography variant="h6">Leave Requests</Typography>
-                  <Button variant="contained" startIcon={<AddCircleOutlineIcon />} onClick={() => console.log("Add Leave for user:", selectedUserId)}>
+                  <Button variant="contained" startIcon={<AddCircleOutlineIcon />} onClick={handleOpenAddLeaveModal} disabled={!selectedUserId}>
                     Add Leave
                   </Button>
                 </Box>
@@ -231,6 +331,62 @@ export default function AdminLeaveWFHManagementPage() {
           </Grid>
         )
       )}
+
+      {/* Add Leave Modal */}
+      <Dialog open={addLeaveModalOpen} onClose={handleCloseAddLeaveModal}>
+        <DialogTitle>Add New Leave Request</DialogTitle>
+        <DialogContent>
+          <DialogContentText sx={{mb: 2}}>
+            Select leave type, dates, and provide a reason if necessary for user ID: {selectedUserId}.
+          </DialogContentText>
+          {submissionError && <Typography color="error" sx={{ mb: 2 }}>{submissionError}</Typography>}
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <InputLabel id="leave-type-label">Leave Type</InputLabel>
+            <Select
+              labelId="leave-type-label"
+              name="leave_type"
+              value={newLeaveData.leave_type}
+              onChange={handleAddLeaveChange}
+              label="Leave Type"
+            >
+              {/* TODO: Populate these from a central config or API if they can change */}
+              <MenuItem value="annual">Annual Leave</MenuItem>
+              <MenuItem value="sick">Sick Leave</MenuItem>
+              <MenuItem value="casual">Casual Leave</MenuItem>
+              <MenuItem value="unpaid">Unpaid Leave</MenuItem>
+              <MenuItem value="other">Other</MenuItem>
+            </Select>
+          </FormControl>
+          <DatePicker
+            label="Start Date"
+            value={newLeaveData.start_date}
+            onChange={(date) => handleAddLeaveDateChange('start_date', date)}
+            slotProps={{ textField: { fullWidth: true, sx: { mb: 2 } } }}
+          />
+          <DatePicker
+            label="End Date"
+            value={newLeaveData.end_date}
+            onChange={(date) => handleAddLeaveDateChange('end_date', date)}
+            slotProps={{ textField: { fullWidth: true, sx: { mb: 2 } } }}
+            minDate={newLeaveData.start_date || undefined}
+          />
+          <TextField
+            name="reason"
+            label="Reason (Optional)"
+            multiline
+            rows={3}
+            fullWidth
+            value={newLeaveData.reason}
+            onChange={handleAddLeaveChange}
+            sx={{ mb: 2 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseAddLeaveModal}>Cancel</Button>
+          <Button onClick={handleAddLeaveSubmit} variant="contained">Submit</Button>
+        </DialogActions>
+      </Dialog>
     </Box>
+  </LocalizationProvider>
   );
 }

--- a/new_project_jules/frontend/pages/LeaveRequestsPage.tsx
+++ b/new_project_jules/frontend/pages/LeaveRequestsPage.tsx
@@ -56,8 +56,30 @@ const LeaveRequestsPage: React.FC = () => {
       setLoading(true);
       setError(null);
       try {
-        // TODO: Replace with your actual API endpoint and authentication
-        const response = await fetch('http://localhost:8000/api/v1/leaves'); // Assuming this endpoint returns all relevant leave requests
+        const token = localStorage.getItem('accessToken');
+        if (!token) {
+          setError("Authentication token not found. Please log in again.");
+          setLoading(false);
+          return;
+        }
+
+        const response = await fetch('http://localhost:8000/api/v1/leaves', {
+          headers: {
+            'Authorization': `Bearer ${token}`,
+          },
+        });
+
+        if (response.status === 401) {
+          setError("Unauthorized: Invalid or expired token. Please log in again.");
+          // Optionally, redirect to login or clear token
+          // localStorage.removeItem('accessToken');
+          // localStorage.removeItem('isAuthenticated');
+          // localStorage.removeItem('is_superuser');
+          // navigate('/login'); // Assuming navigate is available
+          setLoading(false);
+          return;
+        }
+
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }


### PR DESCRIPTION
… Leave.

- Updated `LeaveRequestsPage.tsx` to include the authentication token in API requests, resolving a 401 error.
- Enhanced `AdminLeaveWFHManagementPage.tsx` to allow administrators to add leave requests for any user.
  - Added an 'Add Leave' modal with a form for leave details (user, type, dates, reason).
  - Implemented API call to `POST /api/v1/admin/leaves` for creating leaves.
  - Ensured the leave list refreshes after a new leave is added.