### PR TITLE
feat: Implement admin ability to grant additional leave days

### DIFF
--- a/new_project_jules/backend/app/db/crud.py
+++ b/new_project_jules/backend/app/db/crud.py
@@ -178,11 +178,14 @@ def edit_user(
     db_user = get_user(db, user_id)
     if not db_user:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="User not found")
-    update_data = user.dict(exclude_unset=True)
+    update_data = user.model_dump(exclude_unset=True) # Use model_dump for Pydantic v2
 
-    if "password" in update_data:
-        update_data["hashed_password"] = get_password_hash(user.password)
+    if "password" in update_data and update_data["password"] is not None:
+        update_data["hashed_password"] = get_password_hash(update_data["password"])
         del update_data["password"]
+    elif "password" in update_data and update_data["password"] is None: # Explicitly ignore None password
+        del update_data["password"]
+
 
     for key, value in update_data.items():
         setattr(db_user, key, value)

--- a/new_project_jules/backend/app/db/models.py
+++ b/new_project_jules/backend/app/db/models.py
@@ -33,6 +33,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     is_active = Column(Boolean, default=True)
     is_superuser = Column(Boolean, default=False)
+    granted_additional_days = Column(Integer, default=0, nullable=False)
 
     leaves = relationship("Leave", back_populates="owner")
     wfhs = relationship("WFH", back_populates="owner")

--- a/new_project_jules/backend/app/db/schemas.py
+++ b/new_project_jules/backend/app/db/schemas.py
@@ -8,9 +8,12 @@ class UserBase(BaseModel):
     is_superuser: bool = False
     first_name: t.Optional[str] = None
     last_name: t.Optional[str] = None
+    granted_additional_days: int = 0
 
 
 class UserOut(UserBase):
+    id: int # Ensure UserOut also has id if it's meant to be a representation of a user from DB
+    # granted_additional_days is inherited from UserBase
     pass
 
 
@@ -21,13 +24,20 @@ class UserCreate(UserBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-class UserEdit(UserBase):
+class UserEdit(UserBase): # UserBase now includes granted_additional_days, but we want it optional here
     password: t.Optional[str] = None
+    email: t.Optional[str] = None # Make all fields in UserEdit optional
+    is_active: t.Optional[bool] = None
+    is_superuser: t.Optional[bool] = None
+    first_name: t.Optional[str] = None
+    last_name: t.Optional[str] = None
+    granted_additional_days: t.Optional[int] = None # Explicitly make it optional for editing
     model_config = ConfigDict(from_attributes=True)
 
 
-class User(UserBase):
+class User(UserBase): # UserBase now includes granted_additional_days
     id: int
+    # No need to redeclare granted_additional_days if UserBase has it with a default
     model_config = ConfigDict(from_attributes=True)
 
 


### PR DESCRIPTION
This commit introduces functionality for administrators to grant additional leave days to users.

Key changes include:

Backend:
- Added `granted_additional_days` field (default 0) to the User model (in `db/models.py`).
- Updated User schemas (`db/schemas.py`) to include `granted_additional_days`.
- Modified `edit_user` CRUD function (`db/crud.py`) to support updating this new field.
- Added a new admin API endpoint `PUT /api/v1/admin/users/{user_id}/adjust_leave_days` (in `api/api_v1/routers/users.py`) allowing superusers to set the `granted_additional_days` for a user.

Frontend:
- Updated `AdminLeaveWFHManagementPage.tsx`:
  - Added `granted_additional_days` to the User interface.
  - Admins can now view a selected user's `granted_additional_days`.
  - Implemented a modal dialog for admins to set/update the `granted_additional_days` for a selected user.
  - User details (including additional days) are refreshed after update.

The user's process for requesting leave remains unchanged. Admins can use this new feature to allocate additional days to a user, which can then be considered when approving standard leave requests.

Database schema will require updating (e.g., recreating SQLite DB or applying an ALTER TABLE for persistent databases) to reflect the new column in the 'user' table.