### PR TITLE
Refactor: Update drawer visibility for admin users

### DIFF
--- a/new_project_jules/frontend/src/DashboardLayout.tsx
+++ b/new_project_jules/frontend/src/DashboardLayout.tsx
@@ -191,7 +191,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
     path: '/admin/manage-records',
   };
 
-  const menuItems = isSuperuser ? [...baseMenuItems, adminMenuItem] : baseMenuItems;
+  const menuItems = isSuperuser ? [adminMenuItem] : baseMenuItems;
 
   const handleListItemClick = (text: string, path?: string, isParent: boolean = false) => {
     if (path && !isParent) { // Navigable child or standalone item


### PR DESCRIPTION
Admin users will now only see the 'Admin Management' option in the app drawer. Non-admin users will see the standard menu items without the 'Admin Management' option.